### PR TITLE
hide edit itineraries if not author

### DIFF
--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -27,7 +27,9 @@
             <b><%= link_to itinerary.name.truncate(35), itinerary_path(itinerary.id) %></b>
             <em>(<%= pluralize(itinerary.duration, "day") %>)</em>
             <%= link_to(edit_itinerary_path(itinerary.id)) do %>
-              <span class="glyphicon glyphicon-edit"> </span>
+              <% if allowed?(itinerary.user_id) %>
+                <span class="glyphicon glyphicon-edit"> </span>
+              <% end %>
             <% end %>
           </h4>
           <h5><b>Published: </b><%= time_ago_in_words(itinerary.created_at).gsub('about', '') %> ago</h5>


### PR DESCRIPTION
on cities/show pages, users will only see edit buttons to itineraries they are authors of
